### PR TITLE
Fixed path issue breaking resolve tests on windows

### DIFF
--- a/src/utils/resolve.utils.test.js
+++ b/src/utils/resolve.utils.test.js
@@ -10,7 +10,7 @@ describe('Resolve Utils Test', () => {
 		});
 
 		test('should resolve to a path relative to the base', () => {
-			let relative_path = 'scooby/doo';
+			let relative_path = path.join('scooby','doo');
 			let diff = path.relative(resolve(''), resolve(relative_path));
 			expect(diff).toEqual(relative_path);
 		});
@@ -20,19 +20,19 @@ describe('Resolve Utils Test', () => {
 		test('should resolve to `src/resources/stu3` when no arguments are provided', () => {
 			let base = resolveFromVersion();
 			let project_base = base.substr(base.indexOf('src'));
-			expect(project_base).toEqual('src/resources/3_0_1');
+			expect(project_base).toEqual(path.join('src','resources','3_0_1'));
 		});
 
 		test('should resolve to `src/resources/r4` when no relatve path is provided and version is r4', () => {
 			let base = resolveFromVersion('r4');
 			let project_base = base.substr(base.indexOf('src'));
-			expect(project_base).toEqual('src/resources/r4');
+			expect(project_base).toEqual(path.join('src','resources','r4'));
 		});
 
 		test('should resolve a path relative to the version base', () => {
 			let base = resolveFromVersion(VERSION['3_0_1'], 'scooby/doo');
 			let project_base = base.substr(base.indexOf('src'));
-			expect(project_base).toEqual('src/resources/3_0_1/scooby/doo');
+			expect(project_base).toEqual(path.join('src','resources','3_0_1','scooby','doo'));
 		});
 	});
 });


### PR DESCRIPTION
Due to the '/' vs '\\' difference the hard-coded comparison paths in the tests were incorrect on Windows boxes.  I've amended to use path.join to ensure the correct separator is used. 