### PR TITLE
fix: content security policy for GraphiQL on OSX

### DIFF
--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -86,11 +86,8 @@ class Server {
 				helmetConfig || {
 					// Needs https running first
 					hsts: this.env.USE_HTTPS,
-					// GraphiQL on OSX
-					contentSecurityPolicy:
-						process.env.NODE_ENV === 'production'
-							? undefined
-							: false,
+					// GraphQL on OSX
+					contentSecurityPolicy: this.env.IS_PRODUCTION ? undefined : false,
 				},
 			),
 		);

--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -86,6 +86,11 @@ class Server {
 				helmetConfig || {
 					// Needs https running first
 					hsts: this.env.USE_HTTPS,
+					// GraphiQL on OSX
+					contentSecurityPolicy:
+						process.env.NODE_ENV === 'production'
+							? undefined
+							: false,
 				},
 			),
 		);


### PR DESCRIPTION
After following getting started steps `http://localhost:3000/3_0_1/$graphiql` was stuck on "Loading..." for both Firefox and Chrome on OSX. I added the recommended fix (https://github.com/graphql/graphql-playground/issues/1283) and it now works as expected.